### PR TITLE
Deal with Windows bug with os.makedirs exist_ok

### DIFF
--- a/MEK_Installer.pyw
+++ b/MEK_Installer.pyw
@@ -193,7 +193,7 @@ def download_mek_to_folder(install_dir, src_url=None):
                 try:
                     os.makedirs(path.dirname(filepath), exist_ok=True)
                 except FileExistsError:
-                    # Deal wtih Windows bug where exist_ok can just be ignored sometimes.
+                    # Deal with Windows bug where exist_ok can just be ignored sometimes.
                     pass
                     
 

--- a/MEK_Installer.pyw
+++ b/MEK_Installer.pyw
@@ -47,7 +47,7 @@ except:
 
 MEK_LIB_DIRNAME = "mek_lib"
 MEK_DOWNLOAD_URL = "https://github.com/Sigmmma/mek/archive/master.zip"
-VERSION = (2,3,2)
+VERSION = (2,3,3)
 VERSION_STR = "v%s.%s.%s" % VERSION
 
 global installer_updated
@@ -190,7 +190,12 @@ def download_mek_to_folder(install_dir, src_url=None):
             try:
                 filepath = path.join(install_dir, filepath)
 
-                os.makedirs(path.dirname(filepath), exist_ok=True)
+                try:
+                    os.makedirs(path.dirname(filepath), exist_ok=True)
+                except FileExistsError:
+                    # Deal wtih Windows bug where exist_ok can just be ignored sometimes.
+                    pass
+                    
 
                 with mek_zipfile.open(zip_name) as zf, open(filepath, "wb+") as f:
                     filedata = zf.read()


### PR DESCRIPTION
```
Unpacking MEK to "W:\halotest\MEK"
Traceback (most recent call last):
  File "W:\halotest\MEK\MEK_Installer.pyw", line 193, in download_mek_to_folder
    os.makedirs(path.dirname(filepath), exist_ok=True)
  File "C:\Users\Vaporeon\AppData\Local\Programs\Python\Python38\lib\os.py", line 223, in makedirs
    mkdir(name, mode)
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'W:\\halotest\\MEK\\READMES'

```

`exist_ok` ... `FileExistsError`

Bruh

Seems to be related to samba shared network drives.